### PR TITLE
Networking reorganization and improvements

### DIFF
--- a/client/src/main/java/GUI/ChatController.java
+++ b/client/src/main/java/GUI/ChatController.java
@@ -19,7 +19,7 @@ public class ChatController {
 
     public void sendMessage(ActionEvent actionEvent) {
         var req = Main.getSession().sendRequest(new SendMessageRequest(channelNameText.getText(), newMessageText.getText()));
-        req.onResponse(GenericResponse.class, (s, r) -> {
+        req.onResponse((s, r) -> {
             System.out.println(r.response.name());
             if (r.response == Response.OK) {
                 System.out.println("Sent message");

--- a/client/src/main/java/GUI/LoginController.java
+++ b/client/src/main/java/GUI/LoginController.java
@@ -63,7 +63,7 @@ public class LoginController {
         //if (currentScene.getFocusOwner() == usernameText.getStyleableNode())
         System.out.println("Checking user exists");
         var req = Main.getSession().sendRequest(new CheckUsernameRequest(usernameText.getText()));
-        req.onResponse(CheckNameResponse.class, (s, r) -> {
+        req.onResponse((s, r) -> {
             if (r.result == Result.NAME_FREE) {
                 Platform.runLater(() -> {
                     passwordConfirmation.setVisible(true);
@@ -92,7 +92,7 @@ public class LoginController {
         if (passwordText.getText().equals(passwordConfirmation.getText())) {
             noMatch.setText("");
             var req = Main.getSession().sendRequest(new RegisterRequest(usernameText.getText(), passwordText.getText()));
-            req.onResponse(GenericResponse.class, (s, r) -> {
+            req.onResponse((s, r) -> {
                 System.out.println(r.response);
                 if (r.response == Response.OK) {
                     noMatch.setText("User registered!");
@@ -112,7 +112,7 @@ public class LoginController {
          * If not, then tell wrong password
          */
         var req = Main.getSession().sendRequest(new PasswordLoginRequest(usernameText.getText(), passwordText.getText()));
-        req.onResponse(GenericResponse.class, (s, r) -> {
+        req.onResponse((s, r) -> {
             if (r.response == Response.OK) {
                 Platform.runLater(this::changeToMainMenu);
             } else {

--- a/client/src/main/java/GUI/Main.java
+++ b/client/src/main/java/GUI/Main.java
@@ -41,10 +41,10 @@ public class Main extends Application {
 
     public static ClientSession connectClient(String address) {
         if (client == null) {
-            client = new ClientNetworkingManager();
+            client = new ClientNetworkingManager(DEFAULT_PORT);
         }
 
-        session = client.connect(address, DEFAULT_PORT);
+        session = client.connect(address);
         return session;
     }
 

--- a/client/src/main/java/GUI/MainMenuController.java
+++ b/client/src/main/java/GUI/MainMenuController.java
@@ -35,7 +35,7 @@ public class MainMenuController {
 
     public void joinRoom(ActionEvent actionEvent) {
         var req = Main.getSession().sendRequest(new JoinChannelRequest(channelNameText.getText(), channelPasswordText.getText()));
-        req.onResponse(GenericResponse.class, (s, r) -> {
+        req.onResponse((s, r) -> {
             System.out.println(r.response.name());
             if (r.response == Response.OK) {
                 System.out.println("Joined channel:");
@@ -46,7 +46,7 @@ public class MainMenuController {
     }
     public void checkRoomName(ActionEvent actionEvent) {
         var req = Main.getSession().sendRequest(new CheckChannelNameRequest(channelNameText.getText()));
-        req.onResponse(CheckNameResponse.class, (s, r) -> {
+        req.onResponse((s, r) -> {
             System.out.println(r.result.name());
             if (r.result == Result.NAME_FREE) {
                 System.out.println("Room name free");
@@ -65,7 +65,7 @@ public class MainMenuController {
                         channelPasswordText.getText().isEmpty() ? null: channelPasswordText.getText()
                 )
         );
-        req.onResponse(GenericResponse.class, (s, r) -> {
+        req.onResponse((s, r) -> {
             System.out.println(r.response.name());
             if (r.response == Response.OK) {
                 System.out.println("Created channel");

--- a/networking/src/main/java/networking/AbstractSession.java
+++ b/networking/src/main/java/networking/AbstractSession.java
@@ -1,26 +1,51 @@
 package networking;
 
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.*;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import networking.events.ConnectedEvent;
 import networking.events.DisconnectedEvent;
 import networking.events.ErrorEvent;
+
+import java.io.Serializable;
 
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 
 public abstract class AbstractSession extends ChannelInboundHandlerAdapter {
     protected ChannelHandlerContext ctx;
+    protected volatile boolean closedLocally = false;
+    private final ExceptionForwarder exceptionForwarder = new ExceptionForwarder();
+
+    private class ExceptionForwarder implements ChannelFutureListener {
+        @Override
+        public void operationComplete(ChannelFuture future) {
+            if (!future.isSuccess()) {
+                AbstractSession.this.exceptionCaught(null, future.cause());
+            }
+        }
+    }
 
     protected abstract void callEventHandlers(Event event);
 
-    // @Override
-    // public boolean isActive() {
-    //    return curCtx != null;
-    // }
-
     public Channel getInternalChannel() {
         return ctx == null ? null : ctx.channel();
+    }
+
+    protected void send(Serializable data) {
+        /*if (ctx == null) {
+            exceptionCaught(null, new IllegalStateException("Attempt to send on closed session"));
+            return;
+        }*/
+
+        ctx.writeAndFlush(data).addListener(exceptionForwarder);
+    }
+
+    /**
+     * Closes the session
+     */
+    public void close() {
+        closedLocally = true;
+        ctx.close();
     }
 
     @Override
@@ -29,15 +54,14 @@ public abstract class AbstractSession extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) {
-        callEventHandlers(new DisconnectedEvent());
+    public void handlerRemoved(ChannelHandlerContext ctx) {
+        //this.ctx = null;
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        // TODO: Is this appropriate error handling?
+        System.err.println("Exception occurred in networked session:");
         cause.printStackTrace();
-        ctx.close();
         callEventHandlers(new ErrorEvent(cause));
     }
 }

--- a/networking/src/main/java/networking/AbstractSession.java
+++ b/networking/src/main/java/networking/AbstractSession.java
@@ -4,31 +4,48 @@ import io.netty.channel.*;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import networking.events.ConnectedEvent;
+import networking.events.ConnectionDroppedEvent;
 import networking.events.DisconnectedEvent;
 import networking.events.ErrorEvent;
 
 import java.io.Serializable;
+import java.net.SocketAddress;
 
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 
 public abstract class AbstractSession extends ChannelInboundHandlerAdapter {
-    protected ChannelHandlerContext ctx;
-    protected volatile boolean closedLocally = false;
-    private final ExceptionForwarder exceptionForwarder = new ExceptionForwarder();
+    private ChannelHandlerContext ctx;
+    private SocketAddress targetAddress;
+    protected volatile boolean closedLocally;
+    private final ExceptionForwarder exceptionForwarder;
 
     private class ExceptionForwarder implements ChannelFutureListener {
         @Override
         public void operationComplete(ChannelFuture future) {
             if (!future.isSuccess()) {
-                AbstractSession.this.exceptionCaught(null, future.cause());
+                exceptionCaught(ctx, future.cause());
             }
         }
+    }
+
+    public AbstractSession(SocketAddress targetAddress) {
+        this.targetAddress = targetAddress;
+        closedLocally = false;
+        exceptionForwarder = new ExceptionForwarder();
     }
 
     protected abstract void callEventHandlers(Event event);
 
     public Channel getInternalChannel() {
         return ctx == null ? null : ctx.channel();
+    }
+
+    /**
+     * Gets the target address as a printable string.
+     * Note that the returned address may not be valid, if an invalid address was given
+     */
+    public SocketAddress getTargetAddress() {
+        return targetAddress;
     }
 
     protected void send(Serializable data) {
@@ -60,8 +77,14 @@ public abstract class AbstractSession extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        System.err.println("Exception occurred in networked session:");
+        System.err.println("Exception occurred in networked session with " + getTargetAddress() + ":");
         cause.printStackTrace();
         callEventHandlers(new ErrorEvent(cause));
+        if (ctx.channel().isOpen()) {
+            System.err.println("Session may be in an invalid state and will be closed automatically to avoid unexpected behaviour");
+        } else {
+            System.err.println("Session is already closed and should be discarded");
+        }
+        ctx.close();
     }
 }

--- a/networking/src/main/java/networking/EventDispatcher.java
+++ b/networking/src/main/java/networking/EventDispatcher.java
@@ -2,6 +2,11 @@ package networking;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+/**
+ * Helper class to call multiple event handlers of the same type at the same time
+ * @param <S>
+ * @param <T>
+ */
 public class EventDispatcher<S, T> {
     private final ConcurrentLinkedQueue<EventHandler<S, T>> handlers;
     // private final ConcurrentLinkedQueue<RemovableEventHandler<S, T>> removableHandlers;
@@ -15,11 +20,12 @@ public class EventDispatcher<S, T> {
         handlers.add(handler);
     }
 
-    public boolean remove(EventHandler<?, ?> handler) {
-        return handlers.remove(handler);
+    public void remove(EventHandler<?, ?> handler) {
+        handlers.remove(handler);
     }
 
-    public void call(S session, T event) {
+    public boolean call(S session, T event) {
         handlers.forEach(handler -> handler.handle(session, event));
+        return !handlers.isEmpty(); // TODO: Make this safe against race conditions
     }
 }

--- a/networking/src/main/java/networking/MultiHandlerEventEmitter.java
+++ b/networking/src/main/java/networking/MultiHandlerEventEmitter.java
@@ -3,6 +3,13 @@ package networking;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * Helper class to store and call event handlers with different event types, based on the class of the event or of a type related to the event.
+ * Supports multiple event handlers per event type.
+ * Does nothing if an event with no handlers occurs.
+ * @param <S> Session type for the handlers allowed in this emitter
+ * @param <L> Superclass of all events allowed in this emitter
+ */
 public class MultiHandlerEventEmitter<S, L> {
     private final ConcurrentMap<Class<?>, EventDispatcher<S, ? extends L>> eventHandlers;
 
@@ -12,6 +19,7 @@ public class MultiHandlerEventEmitter<S, L> {
 
     /**
      * Add event handler.
+     * NB! It is expected that the type parameter determines the specific type of T in some manner. Ensuring this is the responsibility of the caller.
      * @return Added event handler, for convenience when using lambdas.
      */
     @SuppressWarnings("unchecked")
@@ -22,32 +30,37 @@ public class MultiHandlerEventEmitter<S, L> {
     }
 
     /**
-     * Remove event handler.
-     * @return True if handler was removed, false otherwise.
+     * Remove specific event handler.
+     * NB! The caller needs to ensure the given type and handler match up.
      */
-    public <T extends L> boolean remove(Class<?> type, EventHandler<S, T> handler) {
+    public void remove(Class<?> type, EventHandler<S, ? extends L> handler) {
         var handlers = eventHandlers.getOrDefault(type, null);
-        return handler != null && handlers.remove(handler);
+        if (handler != null) handlers.remove(handler);
     }
 
     /**
      * Remove all event handlers of type.
-     * @return True if at least one handler was removed, false otherwise.
-     * Note: May return true even if no handlers were removed, if some handlers existed previously, but were removed individually.
      */
-    public boolean removeAll(Class<?> type) {
-        return eventHandlers.remove(type) != null;
+    public void removeAll(Class<?> type) {
+        eventHandlers.remove(type);
     }
 
     public void clear() {
         eventHandlers.clear();
     }
 
+    /**
+     * Call event handlers for given type.
+     * If there are no event handlers registered for the given type, this method will do nothing.
+     * NB! It is expected that the type parameter determines the specific type of T in some manner. Ensuring this is the responsibility of the caller.
+     */
     @SuppressWarnings("unchecked")
-    public <T extends L> void call(Class<?> type, S session, T event) {
+    public <T extends L> boolean call(Class<?> type, S session, T event) {
         var handlers = (EventDispatcher<S, T>) eventHandlers.getOrDefault(type, null);
         if (handlers != null) {
-            handlers.call(session, event);
+            return handlers.call(session, event);
+        } else {
+            return false;
         }
     }
 }

--- a/networking/src/main/java/networking/RequestData.java
+++ b/networking/src/main/java/networking/RequestData.java
@@ -2,5 +2,5 @@ package networking;
 
 import java.io.Serializable;
 
-public interface RequestData extends Serializable {
+public interface RequestData<R extends ResponseData> extends Serializable {
 }

--- a/networking/src/main/java/networking/SingleHandlerEventEmitter.java
+++ b/networking/src/main/java/networking/SingleHandlerEventEmitter.java
@@ -3,6 +3,13 @@ package networking;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * Helper class to store and call event handlers with different event types, based on the class of the event or of a type related to the event.
+ * Supports a single handler per event type.
+ * Throws an exception if an event with no handlers occurs.
+ * @param <S> Session type for the handlers allowed in this emitter
+ * @param <L> Superclass of all events allowed in this emitter
+ */
 public class SingleHandlerEventEmitter<S, L> {
     private final ConcurrentMap<Class<?>, EventHandler<S, ? extends L>> eventHandlers;
 
@@ -12,6 +19,7 @@ public class SingleHandlerEventEmitter<S, L> {
 
     /**
      * Set event handler. Overrides previous handler.
+     * NB! It is expected that the type parameter determines the specific type of T in some manner. Ensuring this is the responsibility of the caller.
      * @return Added event handler, for convenience when using lambdas.
      */
     public <T extends L> EventHandler<S, T> set(Class<?> type, EventHandler<S, T> handler) {
@@ -21,29 +29,35 @@ public class SingleHandlerEventEmitter<S, L> {
 
     /**
      * Remove event handler.
-     * @return True if handler was removed, false otherwise.
      */
-    public <T extends L> boolean remove(Class<?> type, EventHandler<S, T> handler) {
-        return eventHandlers.remove(type, handler);
+    public void remove(Class<?> type, EventHandler<S, ? extends L> handler) {
+        eventHandlers.remove(type, handler);
     }
 
     /**
      * Remove all event handlers by type. Note that as this emitter only supports a single handler per event, this will remove a maximum of 1 handler.
-     * @return True if handler was removed, false otherwise.
      */
-    public boolean removeAll(Class<?> type) {
-        return eventHandlers.remove(type) != null;
+    public void removeAll(Class<?> type) {
+        eventHandlers.remove(type);
     }
 
     public void clear() {
         eventHandlers.clear();
     }
 
+    /**
+     * Call event handlers for given type.
+     * If there are no event handlers registered for the given type, this method will throw an exception.
+     * NB! It is expected that the type parameter determines the specific type of T in some manner. Ensuring this is the responsibility of the caller.
+     */
     @SuppressWarnings("unchecked")
-    public <T extends L> void call(Class<?> type, S session, T event) {
+    public <T extends L> boolean call(Class<?> type, S session, T event) {
         var handler = (EventHandler<S, T>) eventHandlers.getOrDefault(type, null);
         if (handler != null) {
             handler.handle(session, event);
+            return true;
+        } else {
+            return false;
         }
     }
 }

--- a/networking/src/main/java/networking/client/AbstractRequest.java
+++ b/networking/src/main/java/networking/client/AbstractRequest.java
@@ -1,0 +1,23 @@
+package networking.client;
+
+import networking.EventHandler;
+import networking.ResponseData;
+import networking.SingleHandlerEventEmitter;
+
+public abstract class AbstractRequest {
+    protected final int id;
+    protected final ClientSession session;
+
+    public AbstractRequest(int id, ClientSession session) {
+        this.id = id;
+        this.session = session;
+    }
+
+    public abstract void receiveResponse(ResponseData data);
+
+    /**
+     * Check if request is persistent
+     * @return return true to indicate that this request should be kept open by the session, until explicitly closed
+     */
+    public abstract boolean isPersistent();
+}

--- a/networking/src/main/java/networking/client/ClientNetworkingManager.java
+++ b/networking/src/main/java/networking/client/ClientNetworkingManager.java
@@ -12,7 +12,6 @@ import networking.events.ConnectedEvent;
 import networking.events.NotConnectedEvent;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 
 /**
  * Provides a convenient interface for networked communication on the client side.
@@ -22,8 +21,12 @@ import java.net.SocketAddress;
  * Netty code based on https://github.com/netty/netty/blob/4.1/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
  */
 public class ClientNetworkingManager extends ChannelInitializer<SocketChannel> {
-    private ClientSession session;
-    private EventLoopGroup group;
+    private final int port;
+    private volatile ClientSession session;
+
+    public ClientNetworkingManager(int port) {
+        this.port = port;
+    }
 
     @Override
     protected void initChannel(SocketChannel ch) {
@@ -35,44 +38,34 @@ public class ClientNetworkingManager extends ChannelInitializer<SocketChannel> {
         );
     }
 
-    public ClientSession connect(String host, int port) {
+    public synchronized ClientSession connect(String host) {
+        if (session != null) return session;
+
         var targetAddress = new InetSocketAddress(host, port);
-        setupSession(targetAddress);
+        session = new ClientSession(targetAddress);
 
-        Bootstrap b = new Bootstrap();
-        b.group(group);
-        b.channel(NioSocketChannel.class);
-        b.handler(this);
+        var group = new NioEventLoopGroup();
 
-        var connectFuture = b.connect(targetAddress);
+        var bootstrap = new Bootstrap()
+                .group(group)
+                .channel(NioSocketChannel.class)
+                .handler(this);
+
         System.out.println("Client connecting to " + targetAddress + "...");
-        connectFuture.addListener((ChannelFutureListener) future -> {
-            if (future.isSuccess()) {
+        bootstrap.connect(targetAddress).addListener((ChannelFutureListener) connectFuture -> {
+            if (connectFuture.isSuccess()) {
                 session.callEventHandlers(new ConnectedEvent());
             } else {
-                session.callEventHandlers(new NotConnectedEvent(future.cause()));
+                session.callEventHandlers(new NotConnectedEvent(connectFuture.cause()));
             }
-        });
-        connectFuture.channel().closeFuture().addListener((ChannelFutureListener) future -> {
-            System.out.println("Client closing...");
-            cleanupSession();
+
+            connectFuture.channel().closeFuture().addListener(closeFuture -> {
+                session = null;
+                group.shutdownGracefully();
+                System.out.println("Client closing...");
+            });
         });
 
         return session;
-    }
-
-    private synchronized void setupSession(SocketAddress targetAddress) {
-        if (session != null || group != null) throw new IllegalStateException("Client session already running");
-
-        session = new ClientSession(targetAddress);
-        group = new NioEventLoopGroup();
-    }
-
-    private synchronized void cleanupSession() {
-        if (group == null || session == null) throw new IllegalStateException("Client session not running");
-
-        group.shutdownGracefully();
-        group = null;
-        session = null;
     }
 }

--- a/networking/src/main/java/networking/client/ClientSession.java
+++ b/networking/src/main/java/networking/client/ClientSession.java
@@ -2,58 +2,81 @@ package networking.client;
 
 import io.netty.channel.ChannelHandlerContext;
 import networking.*;
+import networking.events.ConnectionDroppedEvent;
+import networking.events.DisconnectedEvent;
 
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ClientSession extends AbstractSession {
-    private final MultiHandlerEventEmitter<ClientSession, Event> eventHandlers;
-    protected final ConcurrentMap<Integer, Request> requests;
+    protected final MultiHandlerEventEmitter<ClientSession, Event> eventHandlers;
+    protected final ConcurrentMap<Integer, AbstractRequest> requests;
 
-    private int previousId = 0;
+    private final AtomicInteger previousId;
 
     public ClientSession() {
         eventHandlers = new MultiHandlerEventEmitter<>();
         requests = new ConcurrentHashMap<>();
+        previousId = new AtomicInteger(0);
     }
 
     protected int getNextId() {
-        return ++previousId;
+        return previousId.getAndIncrement();
     }
 
+    /**
+     * Add an event handler for one of the events
+     */
     public <T extends Event> EventHandler<ClientSession, T> onEvent(Class<T> type, EventHandler<ClientSession, T> handler) {
         return eventHandlers.add(type, handler);
     }
 
-    public <T extends Event> boolean removeEventHandler(Class<T> type, EventHandler<ClientSession, T> handler) {
-        return eventHandlers.remove(type, handler);
+    /**
+     * Remove a given event handler
+     */
+    public <T extends Event> void removeEventHandler(Class<T> type, EventHandler<ClientSession, T> handler) {
+        eventHandlers.remove(type, handler);
     }
 
-    public Request sendRequest(RequestData requestData) {
-        Objects.requireNonNull(requestData, "Cannot send null request");
+    /**
+     * Sends a request over the network
+     * @param requestData request to send
+     * @return object representing the request, which can be used to handle the response
+     */
+    public <R extends ResponseData> Request<R> sendRequest(RequestData<R> requestData) {
+        Objects.requireNonNull(requestData, "Attempt to send null request");
 
         int id = getNextId();
-        var request = new Request(id, this);
+        var request = new Request<R>(id, this);
         requests.put(id, request);
-        ctx.writeAndFlush(new RequestWrapper(id, requestData)).addListener(FIRE_EXCEPTION_ON_FAILURE);
+        send(new RequestWrapper(id, requestData));
 
         return request;
     }
 
+    /**
+     * Sends a persistent request over the network
+     * @param requestData persistent request to send
+     * @return object representing the request, which can be used to handle the responses
+     */
     public PersistentRequest sendPersistentRequest(PersistentRequestData requestData) {
-        Objects.requireNonNull(requestData, "Cannot send null persistent request");
+        Objects.requireNonNull(requestData, "Attempt to send null persistent request");
 
         int id = getNextId();
         var request = new PersistentRequest(id, this);
         requests.put(id, request);
-        ctx.writeAndFlush(new RequestWrapper(id, requestData)).addListener(FIRE_EXCEPTION_ON_FAILURE);
+        send(new RequestWrapper(id, requestData));
 
         return request;
     }
 
+    /**
+     * Closes all open requests, including persistent requests
+     * This should only be called manually if the application changes state and all existing requests should be discarded
+     * This does not need to be called before closing the session, the server will close open requests automatically
+     */
     public void closeAllRequests() {
         requests.forEach((k, v) -> {
             // Have to explicitly close persistent requests
@@ -64,15 +87,8 @@ public class ClientSession extends AbstractSession {
 
     protected void closePersistentRequest(int id) {
         if (requests.remove(id) != null) {
-            ctx.writeAndFlush(new RequestWrapper(id, null)).addListener(FIRE_EXCEPTION_ON_FAILURE);
+            send(new RequestWrapper(id, null));
         }
-    }
-
-    /**
-     * Closes the session
-     */
-    public void close() {
-        ctx.channel().close();
     }
 
     @Override
@@ -87,6 +103,15 @@ public class ClientSession extends AbstractSession {
 
         if (!request.isPersistent()) requests.remove(wrapper.id);
         request.receiveResponse(wrapper.data);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        requests.clear(); // No close messages can be sent for ongoing requests, so we drop all ongoing requests that have not been closed.
+        if (!closedLocally) { // If client has not called close, assume the connection was dropped and call relevant event handlers
+            callEventHandlers(new ConnectionDroppedEvent());
+        }
+        callEventHandlers(new DisconnectedEvent());
     }
 
     @Override

--- a/networking/src/main/java/networking/client/ClientSession.java
+++ b/networking/src/main/java/networking/client/ClientSession.java
@@ -5,6 +5,7 @@ import networking.*;
 import networking.events.ConnectionDroppedEvent;
 import networking.events.DisconnectedEvent;
 
+import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -16,7 +17,8 @@ public class ClientSession extends AbstractSession {
 
     private final AtomicInteger previousId;
 
-    public ClientSession() {
+    public ClientSession(SocketAddress targetAddress) {
+        super(targetAddress);
         eventHandlers = new MultiHandlerEventEmitter<>();
         requests = new ConcurrentHashMap<>();
         previousId = new AtomicInteger(0);

--- a/networking/src/main/java/networking/client/PersistentRequest.java
+++ b/networking/src/main/java/networking/client/PersistentRequest.java
@@ -1,12 +1,42 @@
 package networking.client;
 
-public class PersistentRequest extends Request {
+import networking.EventHandler;
+import networking.ResponseData;
+import networking.SingleHandlerEventEmitter;
+
+/**
+ * Object representing a persistent request, which can receive multiple responses
+ * Allows setting a handler to be called when a specific type of response is received
+ */
+public class PersistentRequest extends AbstractRequest {
+    protected final SingleHandlerEventEmitter<ClientSession, ResponseData> handlers;
+
     public PersistentRequest(int id, ClientSession session) {
         super(id, session);
+        handlers = new SingleHandlerEventEmitter<>();
     }
 
+    /**
+     * Sets the event handler to be called upon receiving a response of the specified type. Overrides previously set handler for this type of response.
+     */
+    public <T extends ResponseData> void onResponse(Class<T> type, EventHandler<ClientSession, T> handler) {
+        handlers.set(type, handler);
+    }
+
+    /**
+     * Closes the persistent request and notifies the server, if possible
+     * Note that requests will be closed automatically if the session closes, so there is no need to close requests if the session has already been closed
+     * It is safe to close a request multiple times or close a request after the underlying session has been closed
+     */
     public void close() {
         session.closePersistentRequest(id);
+    }
+
+    @Override
+    public void receiveResponse(ResponseData data) {
+        if (!handlers.call(data.getClass(), session, data)) {
+            throw new RuntimeException("No handler for response of type " + data.getClass().getName() + " registered");
+        }
     }
 
     @Override

--- a/networking/src/main/java/networking/events/ConnectionDroppedEvent.java
+++ b/networking/src/main/java/networking/events/ConnectionDroppedEvent.java
@@ -1,0 +1,9 @@
+package networking.events;
+
+import networking.Event;
+
+/**
+ * Occurs on client if connection to server was unexpectedly lost
+ */
+public class ConnectionDroppedEvent implements Event {
+}

--- a/networking/src/main/java/networking/events/ServerStoppedEvent.java
+++ b/networking/src/main/java/networking/events/ServerStoppedEvent.java
@@ -1,0 +1,10 @@
+package networking.events;
+
+import networking.Event;
+
+/**
+ * Occurs on server *after* the server has stopped and all open channels and threads have been cleaned up.
+ * Note: Session will be null when this event occurs
+ */
+public class ServerStoppedEvent implements Event {
+}

--- a/networking/src/main/java/networking/requests/CheckChannelNameRequest.java
+++ b/networking/src/main/java/networking/requests/CheckChannelNameRequest.java
@@ -1,8 +1,9 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.CheckNameResponse;
 
-public class CheckChannelNameRequest implements RequestData {
+public class CheckChannelNameRequest implements RequestData<CheckNameResponse> {
     public final String channelName;
 
     public CheckChannelNameRequest(String channelName) {

--- a/networking/src/main/java/networking/requests/CheckUsernameRequest.java
+++ b/networking/src/main/java/networking/requests/CheckUsernameRequest.java
@@ -1,8 +1,9 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.CheckNameResponse;
 
-public class CheckUsernameRequest implements RequestData {
+public class CheckUsernameRequest implements RequestData<CheckNameResponse> {
     public final String username;
 
     public CheckUsernameRequest(String username) {

--- a/networking/src/main/java/networking/requests/CreateChannelRequest.java
+++ b/networking/src/main/java/networking/requests/CreateChannelRequest.java
@@ -1,8 +1,9 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.GenericResponse;
 
-public class CreateChannelRequest implements RequestData {
+public class CreateChannelRequest implements RequestData<GenericResponse> {
     public final String channelName;
     public final String channelPassword;
 

--- a/networking/src/main/java/networking/requests/DebugRequest.java
+++ b/networking/src/main/java/networking/requests/DebugRequest.java
@@ -1,8 +1,9 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.DebugResponse;
 
-public class DebugRequest implements RequestData {
+public class DebugRequest implements RequestData<DebugResponse> {
     public final String message;
 
     public DebugRequest(String message) {

--- a/networking/src/main/java/networking/requests/JoinChannelRequest.java
+++ b/networking/src/main/java/networking/requests/JoinChannelRequest.java
@@ -1,11 +1,12 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.GenericResponse;
 
 /**
  * Sent by client to server to request joining a new channel.
  */
-public class JoinChannelRequest implements RequestData {
+public class JoinChannelRequest implements RequestData<GenericResponse> {
     public final String channelName;
     public final String channelPassword;
 

--- a/networking/src/main/java/networking/requests/PasswordLoginRequest.java
+++ b/networking/src/main/java/networking/requests/PasswordLoginRequest.java
@@ -1,8 +1,9 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.GenericResponse;
 
-public class PasswordLoginRequest implements RequestData {
+public class PasswordLoginRequest implements RequestData<GenericResponse> {
     public final String username;
     public final String password;
 

--- a/networking/src/main/java/networking/requests/RegisterRequest.java
+++ b/networking/src/main/java/networking/requests/RegisterRequest.java
@@ -1,8 +1,9 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.GenericResponse;
 
-public class RegisterRequest implements RequestData {
+public class RegisterRequest implements RequestData<GenericResponse> {
     public final String username;
     public final String password;
 

--- a/networking/src/main/java/networking/requests/SendMessageRequest.java
+++ b/networking/src/main/java/networking/requests/SendMessageRequest.java
@@ -1,11 +1,12 @@
 package networking.requests;
 
 import networking.RequestData;
+import networking.responses.GenericResponse;
 
 /**
  * Sent by client to send new message to channel
  */
-public class SendMessageRequest implements RequestData {
+public class SendMessageRequest implements RequestData<GenericResponse> {
     public String channelName;
     public String text;
 

--- a/networking/src/main/java/networking/server/AbstractRequest.java
+++ b/networking/src/main/java/networking/server/AbstractRequest.java
@@ -5,16 +5,12 @@ import java.io.Serializable;
 
 public abstract class AbstractRequest<T extends Serializable> {
     protected final int id;
-    public final ServerSession session;
+    protected final ServerSession<?> session;
     public final T data;
 
-    public AbstractRequest(int id, ServerSession session, T data) {
+    public AbstractRequest(int id, ServerSession<?> session, T data) {
         this.id = id;
         this.session = session;
         this.data = data;
-    }
-
-    public void sendResponse(ResponseData responseData) {
-        session.sendResponse(id, responseData);
     }
 }

--- a/networking/src/main/java/networking/server/PersistentRequest.java
+++ b/networking/src/main/java/networking/server/PersistentRequest.java
@@ -1,6 +1,8 @@
 package networking.server;
 
 import networking.PersistentRequestData;
+import networking.ResponseData;
+
 import java.util.function.Consumer;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -8,9 +10,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class PersistentRequest<T extends PersistentRequestData> extends AbstractRequest<T> {
     protected final ConcurrentLinkedQueue<Consumer<PersistentRequest<T>>> closeHandlers;
 
-    public PersistentRequest(int id, ServerSession session, T data) {
+    public PersistentRequest(int id, ServerSession<?> session, T data) {
         super(id, session, data);
         closeHandlers = new ConcurrentLinkedQueue<>();
+    }
+
+    public void sendResponse(ResponseData responseData) {
+        session.sendResponse(id, responseData);
     }
 
     public void onClose(Consumer<PersistentRequest<T>> handler) {

--- a/networking/src/main/java/networking/server/Request.java
+++ b/networking/src/main/java/networking/server/Request.java
@@ -1,9 +1,14 @@
 package networking.server;
 
 import networking.RequestData;
+import networking.ResponseData;
 
-public class Request<T extends RequestData> extends AbstractRequest<T> {
-    public Request(int id, ServerSession session, T data) {
+public class Request<T extends RequestData<R>, R extends ResponseData> extends AbstractRequest<T> {
+    public Request(int id, ServerSession<?> session, T data) {
         super(id, session, data);
+    }
+
+    public void sendResponse(R responseData) {
+        session.sendResponse(id, responseData);
     }
 }

--- a/networking/src/main/java/networking/server/ServerNetworkingManager.java
+++ b/networking/src/main/java/networking/server/ServerNetworkingManager.java
@@ -69,7 +69,7 @@ public class ServerNetworkingManager<U> extends ChannelInitializer<SocketChannel
         p.addLast(
                 new ObjectEncoder(),
                 new ObjectDecoder(ClassResolvers.cacheDisabled(null)),
-                new ServerSession<>(this)
+                new ServerSession<>(ch.remoteAddress(), this)
         );
     }
 

--- a/networking/src/main/java/networking/server/ServerNetworkingManager.java
+++ b/networking/src/main/java/networking/server/ServerNetworkingManager.java
@@ -9,6 +9,7 @@ import io.netty.handler.codec.serialization.ClassResolvers;
 import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ObjectEncoder;
 import networking.*;
+import networking.events.ServerStoppedEvent;
 
 /**
  * Provides a convenient interface for networked communication on the server side.
@@ -91,7 +92,9 @@ public class ServerNetworkingManager<U> extends ChannelInitializer<SocketChannel
             serverChannel.closeFuture().addListener(closeFuture -> {
                 serverChannel = null;
                 bossGroup.shutdownGracefully();
-                workerGroup.shutdownGracefully();
+                workerGroup.shutdownGracefully().addListener(terminationFuture -> {
+                    callEventHandlers(null, new ServerStoppedEvent());
+                });
                 System.out.println("Server stopping...");
             });
         });

--- a/networking/src/main/java/networking/server/ServerSession.java
+++ b/networking/src/main/java/networking/server/ServerSession.java
@@ -3,12 +3,11 @@ package networking.server;
 import io.netty.channel.ChannelHandlerContext;
 import networking.*;
 import networking.events.ConnectedEvent;
+import networking.events.DisconnectedEvent;
 
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 
 /**
  * Class to represent client session on server
@@ -36,7 +35,7 @@ public class ServerSession<U> extends AbstractSession {
     public void sendResponse(int id, ResponseData responseData) {
         Objects.requireNonNull(responseData, "Cannot send null response");
 
-        ctx.writeAndFlush(new ResponseWrapper(id, responseData)).addListener(FIRE_EXCEPTION_ON_FAILURE);
+        send(new ResponseWrapper(id, responseData));
     }
 
     @Override
@@ -59,7 +58,7 @@ public class ServerSession<U> extends AbstractSession {
         } else {
             // Normal request sent. Call appropriate handlers.
 
-            var request = new Request<>(wrapper.id, this, (RequestData) wrapper.data);
+            var request = new Request<>(wrapper.id, this, (RequestData<?>) wrapper.data);
             eventEmitter.callRequestHandlers(this, request);
         }
 
@@ -73,7 +72,7 @@ public class ServerSession<U> extends AbstractSession {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
         persistentRequests.forEach((k, v) -> v.callCloseHandlers());
-        super.channelInactive(ctx);
+        callEventHandlers(new DisconnectedEvent());
     }
 
     @Override

--- a/networking/src/main/java/networking/server/ServerSession.java
+++ b/networking/src/main/java/networking/server/ServerSession.java
@@ -5,6 +5,7 @@ import networking.*;
 import networking.events.ConnectedEvent;
 import networking.events.DisconnectedEvent;
 
+import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -19,7 +20,8 @@ public class ServerSession<U> extends AbstractSession {
 
     protected U user;
 
-    public ServerSession(ServerNetworkingManager<U> eventEmitter) {
+    public ServerSession(SocketAddress targetAddress, ServerNetworkingManager<U> eventEmitter) {
+        super(targetAddress);
         this.eventEmitter = eventEmitter;
         persistentRequests = new ConcurrentHashMap<>();
     }

--- a/networking/src/test/java/networking/NettyClientServerTest.java
+++ b/networking/src/test/java/networking/NettyClientServerTest.java
@@ -40,7 +40,7 @@ class NettyClientServerTest {
         server.start();
 
 
-        var clientSession = new ClientNetworkingManager().connect("localhost", testPort);
+        var clientSession = new ClientNetworkingManager(testPort).connect("localhost");
 
         clientSession.onEvent(ConnectedEvent.class, (s, e) -> System.out.println("Client connected"));
         clientSession.onEvent(ConnectedEvent.class, (s, e) -> {

--- a/networking/src/test/java/networking/NettyClientServerTest.java
+++ b/networking/src/test/java/networking/NettyClientServerTest.java
@@ -45,7 +45,7 @@ class NettyClientServerTest {
         clientSession.onEvent(ConnectedEvent.class, (s, e) -> System.out.println("Client connected"));
         clientSession.onEvent(ConnectedEvent.class, (s, e) -> {
             var req = s.sendRequest(new DebugRequest("Klient siin!"));
-            req.onResponse(DebugResponse.class, (ss, r) -> {
+            req.onResponse((ss, r) -> {
                 System.out.println("Client received response: " + r.message);
                 clientCheck.complete(true);
                 pingCount.incrementAndGet();

--- a/server/src/main/java/server/ChatRuumServer.java
+++ b/server/src/main/java/server/ChatRuumServer.java
@@ -1,6 +1,7 @@
 package server;
 
 import networking.events.ConnectedEvent;
+import networking.events.ConnectionDroppedEvent;
 import networking.events.DisconnectedEvent;
 import networking.events.ErrorEvent;
 import networking.requests.*;
@@ -28,13 +29,8 @@ public class ChatRuumServer {
     }
 
     private void setupServer() {
-        server.onEvent(ConnectedEvent.class, (s, e) -> System.out.println("Client connected: " + s.getInternalChannel().remoteAddress()));
-        server.onEvent(DisconnectedEvent.class, (s, e) -> System.out.println("Client disconnected: " + s.getInternalChannel().remoteAddress()));
-
-        server.onEvent(ErrorEvent.class, (s, e) -> {
-            System.out.println("Error while networking with client " + s.getInternalChannel().remoteAddress() + ". Closing client connection.");
-            s.close();
-        });
+        server.onEvent(ConnectedEvent.class, (s, e) -> System.out.println("Client connected: " + s.getTargetAddress()));
+        server.onEvent(DisconnectedEvent.class, (s, e) -> System.out.println("Client disconnected: " + s.getTargetAddress()));
 
         server.onRequest(RegisterRequest.class, (session, req) -> {
             System.out.println("Registering...");

--- a/server/src/main/java/server/ChatRuumServer.java
+++ b/server/src/main/java/server/ChatRuumServer.java
@@ -2,6 +2,7 @@ package server;
 
 import networking.events.ConnectedEvent;
 import networking.events.DisconnectedEvent;
+import networking.events.ErrorEvent;
 import networking.requests.*;
 import networking.persistentrequests.ViewChannelRequest;
 import networking.responses.*;
@@ -29,6 +30,11 @@ public class ChatRuumServer {
     private void setupServer() {
         server.onEvent(ConnectedEvent.class, (s, e) -> System.out.println("Client connected: " + s.getInternalChannel().remoteAddress()));
         server.onEvent(DisconnectedEvent.class, (s, e) -> System.out.println("Client disconnected: " + s.getInternalChannel().remoteAddress()));
+
+        server.onEvent(ErrorEvent.class, (s, e) -> {
+            System.out.println("Error while networking with client " + s.getInternalChannel().remoteAddress() + ". Closing client connection.");
+            s.close();
+        });
 
         server.onRequest(RegisterRequest.class, (session, req) -> {
             System.out.println("Registering...");

--- a/server/src/test/java/server/ChatRuumServerTest.java
+++ b/server/src/test/java/server/ChatRuumServerTest.java
@@ -35,7 +35,7 @@ class ChatRuumServerTest {
 
         var connectFuture = new CompletableFuture<Void>();
         exceptionCount = new AtomicInteger(0);
-        session = new ClientNetworkingManager().connect("localhost", testPort);
+        session = new ClientNetworkingManager(testPort).connect("localhost");
         session.onEvent(ConnectedEvent.class, (s, e) -> connectFuture.complete(null));
         session.onEvent(ErrorEvent.class, (s, e) -> exceptionCount.incrementAndGet());
         connectFuture.get(2, TimeUnit.SECONDS);


### PR DESCRIPTION
Lots of minor changes to improve networking:

- Added more comments to the networking package.
- Specified expected response as part of the RequestData type. Removed need to explicitly specify responce class for one-off requests.
- Removed extra thread creation in ServerNetworkingManager start and stop methods. This allows the server to function with only Netty threads running.
- Improved robustness of error handling and reporting for client and server: 
  - Errors are now correctly routed to ErrorEvent handlers, even after the session has been closed.
  - Added separate ConnectionDroppedEvent for cases when client unexpectedly loses connection to server.
  - Receiving responses or requests with no handler results in an exceptions during networking (ErrorEvent handlers are notified of these exceptions)
  - Currently sessions are closed automatically if any error occurs during networking, to avoid leaving the networking system in an invalid state.